### PR TITLE
Make `product_view::iterator`'s parent constructor explicit

### DIFF
--- a/include/cor3ntin/rangesnext/product.hpp
+++ b/include/cor3ntin/rangesnext/product.hpp
@@ -56,7 +56,7 @@ template <r::view... V>
         using difference_type = std::common_type_t<r::range_difference_t<V>...>;
 
         iterator() = default;
-        iterator(parent *view, r::iterator_t<V>... its)
+        explicit iterator(parent *view, r::iterator_t<V>... its)
             : view_(view), its_(std::move(its)...) {
         }
 


### PR DESCRIPTION
The corresponding sentinel constructor is explicit. I don't think you want implicit conversions from the view to the iterator in the empty case.